### PR TITLE
style(home): remove "Get in touch" section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -76,16 +76,6 @@ const updateMode = 'latest';
     </section>
 
     <UpdatesFeed mode={updateMode} limit={3} excludedProjectIds={featuredProjectIds} />
-
-    <section class="cta" data-reveal>
-      <h2>Get in touch</h2>
-      <p>
-        Questions, collaborations, or just a good conversation — my inbox is open.
-      </p>
-      <div class="cta-buttons">
-        <a href={`mailto:${siteConfig.author.email}`} class="btn-secondary">Email me</a>
-      </div>
-    </section>
   </div>
 
   <style>
@@ -181,35 +171,6 @@ const updateMode = 'latest';
       outline-offset: 2px;
     }
 
-    .btn-secondary {
-      display: inline-block;
-      padding: 0.75rem 1.5rem;
-      background: transparent;
-      color: var(--color-text);
-      font-weight: 500;
-      font-size: 0.9375rem;
-      text-decoration: none;
-      border: 1px solid var(--color-border);
-      border-radius: 6px;
-      transition:
-        border-color 0.2s ease,
-        transform 0.3s var(--ease-out-expo),
-        box-shadow 0.3s var(--ease-out-expo);
-      min-height: 44px;
-      min-width: 44px;
-    }
-
-    .btn-secondary:hover {
-      border-color: var(--color-text-secondary);
-      transform: translateY(-1px);
-      box-shadow: var(--shadow-md);
-    }
-    
-    .btn-secondary:focus-visible {
-      outline: 2px solid var(--color-accent);
-      outline-offset: 2px;
-    }
-
     .hero-right {
       padding-top: 0.5rem;
     }
@@ -284,31 +245,6 @@ const updateMode = 'latest';
       line-height: 1.5;
     }
 
-    .cta {
-      padding: 3rem 0;
-      border-top: 1px solid var(--color-border);
-    }
-
-    .cta h2 {
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin-bottom: 0.75rem;
-      letter-spacing: -0.01em;
-    }
-
-    .cta p {
-      font-size: 1rem;
-      color: var(--color-text-secondary);
-      margin-bottom: 1.5rem;
-      max-width: 500px;
-      line-height: 1.6;
-    }
-
-    .cta-buttons {
-      display: flex;
-      gap: 1rem;
-    }
-
     @media (max-width: 768px) {
       .home-page {
         padding: 0 1rem 3rem;
@@ -331,8 +267,7 @@ const updateMode = 'latest';
         flex-direction: column;
       }
 
-      .btn-primary,
-      .btn-secondary {
+      .btn-primary {
         text-align: center;
         width: 100%;
       }
@@ -343,15 +278,6 @@ const updateMode = 'latest';
 
       .case-arrow {
         opacity: 1;
-      }
-
-      .cta-buttons {
-        flex-direction: column;
-      }
-
-      .cta-buttons .btn-primary,
-      .cta-buttons .btn-secondary {
-        width: 100%;
       }
     }
   </style>


### PR DESCRIPTION
## Summary

Removes the closing "Get in touch" CTA section from the home page (`src/pages/index.astro`).

## Changes

- Deleted the `<section class="cta">` block containing the heading, blurb, and "Email me" button.
- Removed the CSS that became orphaned with it: `.cta`, `.cta h2`, `.cta p`, `.cta-buttons`, `.btn-secondary` (and its `:hover` / `:focus-visible` states), plus the matching `@media (max-width: 768px)` overrides.
- `siteConfig` import is retained since the SEO block still uses it.

The page now ends with the Latest Updates feed. Contact links in the footer are untouched.

## Verification

`bun run build` passes (`astro check` clean, 28 pages built). Confirmed "Get in touch" and `btn-secondary` no longer appear in `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)