### PR TITLE
ci: fix publication sync gate, rewire audit triggers, add PR validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Action version bumps were previously manual. npm deps are deliberately
+  # left out; Astro upgrades are handled by hand.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(ci)"
+    open-pull-requests-limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+# Validates PRs before merge. Without this, `astro check` only ran on main
+# after a merge, so a type error reached the deploy job before anyone saw it.
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # `bun run build` runs `astro check` (type-check) before building.
+      - name: Type-check and build
+        run: bun run build

--- a/.github/workflows/doc-cleaner-claude.yml
+++ b/.github/workflows/doc-cleaner-claude.yml
@@ -1,9 +1,26 @@
 name: "Documentation Cleaner"
 
-# Manual-only: the weekly schedule was retired after 20 consecutive runs
-# produced no PRs (docs had converged). Dispatch it after a refactor, when
-# there is actually drift for it to find.
+# Reactive, not scheduled: the weekly cron was retired after 20 consecutive
+# runs produced no PRs (docs had converged). Docs only drift when the code
+# they describe changes, so this fires on pushes to main that touch build
+# config, routing, or scripts — not on content or styling edits.
+#
+# Note the paths below deliberately exclude the docs themselves. Merging this
+# workflow's own PR therefore cannot retrigger it.
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'astro.config.mjs'
+      - 'package.json'
+      - 'tsconfig.json'
+      - 'src/config.ts'
+      - 'src/content.config.ts'
+      - 'src/pages.config.ts'
+      - 'src/pages/**'
+      - 'scripts/**'
+      - '.github/workflows/**'
   workflow_dispatch:
 
 permissions:
@@ -12,6 +29,9 @@ permissions:
 
 concurrency:
   group: "doc-cleaner"
+  # Only the latest state of main is worth auditing; superseded runs would
+  # otherwise queue for a full 20 minutes each.
+  cancel-in-progress: true
 
 jobs:
   clean:

--- a/.github/workflows/doc-cleaner-claude.yml
+++ b/.github/workflows/doc-cleaner-claude.yml
@@ -1,15 +1,14 @@
 name: "Documentation Cleaner"
 
+# Manual-only: the weekly schedule was retired after 20 consecutive runs
+# produced no PRs (docs had converged). Dispatch it after a refactor, when
+# there is actually drift for it to find.
 on:
-  schedule:
-    - cron: "23 1 * * 0" # Weekly on Sunday
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
-  issues: write
-  id-token: write
 
 concurrency:
   group: "doc-cleaner"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,11 +41,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/sync-publications-fused.yml
+++ b/.github/workflows/sync-publications-fused.yml
@@ -1,3 +1,5 @@
+# NOTE: publish.yml chains off this workflow by name via `workflow_run`.
+# Renaming it silently stops synced publications from being deployed.
 name: Sync Publications (Fused)
 
 on:
@@ -8,9 +10,13 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: "sync-publications"
+
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -23,16 +29,23 @@ jobs:
         env:
           OPENALEX_API_KEY: ${{ secrets.OPENALEX_API_KEY }}
 
+      # Stage first, then compare the index: `git diff` alone ignores untracked
+      # files, so a run whose only change was a newly published paper reported
+      # "no changes" and committed nothing.
       - name: Check for changes
         id: changes
         run: |
-          git diff --quiet src/content/publications/ && echo "changed=false" >> $GITHUB_OUTPUT || echo "changed=true" >> $GITHUB_OUTPUT
+          git add src/content/publications/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Commit and push
         if: steps.changes.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/content/publications/
           git commit -m "chore: sync publications from ORCID + OpenAlex"
           git push

--- a/.github/workflows/wcag-audit-claude.yml
+++ b/.github/workflows/wcag-audit-claude.yml
@@ -1,15 +1,14 @@
 name: "WCAG Compliance Auditor"
 
+# Manual-only: the weekly schedule was retired after 19 consecutive runs
+# produced no PRs (the site was already AA-clean). Dispatch it after UI or
+# style changes, when there is actually something new to audit.
 on:
-  schedule:
-    - cron: "42 19 * * 0" # Weekly on Sunday
   workflow_dispatch:
 
 permissions:
   contents: write
   pull-requests: write
-  issues: write
-  id-token: write
 
 concurrency:
   group: "wcag-audit"

--- a/.github/workflows/wcag-audit-claude.yml
+++ b/.github/workflows/wcag-audit-claude.yml
@@ -1,9 +1,22 @@
 name: "WCAG Compliance Auditor"
 
-# Manual-only: the weekly schedule was retired after 19 consecutive runs
-# produced no PRs (the site was already AA-clean). Dispatch it after UI or
-# style changes, when there is actually something new to audit.
+# Reactive, not scheduled: the weekly cron was retired after 19 consecutive
+# runs produced no PRs (the site was already AA-clean). Accessibility can only
+# regress when markup, styles, or content change, so this fires on pushes to
+# main that touch those files.
+#
+# Unlike the doc cleaner, this workflow's own fixes land in .astro/.css files
+# that match the paths below, so merging its PR triggers one more run. That
+# run finds nothing and opens no PR, so it self-terminates rather than looping.
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**/*.astro'
+      - 'src/**/*.css'
+      - 'src/**/*.mdx'
+      - 'src/styles/**'
   workflow_dispatch:
 
 permissions:
@@ -12,6 +25,9 @@ permissions:
 
 concurrency:
   group: "wcag-audit"
+  # Only the latest state of main is worth auditing; superseded runs would
+  # otherwise queue for a full 30 minutes each.
+  cancel-in-progress: true
 
 jobs:
   audit:


### PR DESCRIPTION
Applies the six cleanup items from the GitHub Actions audit, plus rewires the two Claude audits to run reactively on pushes to `main`.

## 1. Bug: new publications were never committed
`sync-publications-fused.yml` gated its commit on `git diff --quiet src/content/publications/`, but the sync script *creates* new `.mdx` files (`scripts/sync-publications-fused.ts:381`) and `git diff` ignores untracked files. A run whose only change was a newly published paper, exactly what the workflow exists for, reported "no changes" and committed nothing. It was masked in practice because citation-count churn usually dirties an existing file in the same run.

Now stages first and compares the index. Verified against three scenarios:

| Scenario | Old gate | New gate |
| --- | --- | --- |
| Brand-new publication only | `changed=false` (bug) | `changed=true` |
| No changes | `changed=false` | `changed=false` |
| Existing file modified | `changed=true` | `changed=true` |

## 2. Audit triggers: weekly cron → push to main
The Claude doc-cleaner and WCAG auditor earned their keep early (PRs #2–#6, #9, #12), but the last one landed 2026-03-08. Since then: **39 scheduled runs, zero PRs**, because a fixed weekly cadence has no relationship to when drift actually appears.

Both now fire on pushes to `main`, scoped by path to their own remit:

| Workflow | Fires when these change |
| --- | --- |
| Documentation Cleaner | `astro.config.mjs`, `package.json`, `tsconfig.json`, `src/*.config.ts`, `src/pages/**`, `scripts/**`, `.github/workflows/**` |
| WCAG Auditor | `src/**/*.astro`, `src/**/*.css`, `src/**/*.mdx`, `src/styles/**` |

Recursion behaviour differs between the two, deliberately:
- The doc cleaner's paths **exclude the docs it edits**, so merging its own PR cannot retrigger it.
- The WCAG auditor's fixes **do** land in `.astro`/`.css` files, so merging its PR triggers one more run. That run finds nothing and opens no PR, so it self-terminates rather than looping.

Both use `cancel-in-progress: true`, so a burst of pushes doesn't queue several 20-30 minute Claude runs.

## 3. Removed unused Node setup from the deploy path
`publish.yml` installed Node 24 but only ever ran `bun install` / `bun run build`. Confirmed the build passes with no Node present at all.

## 4. Added PR validation (new `ci.yml`)
There was no CI, so `astro check` only ran on `main` after a merge, including on the bot PRs merged without review. Now runs on every `pull_request`.

## 5. Trimmed over-broad permissions
Dropped `issues: write` (neither prompt touches issues) and `id-token: write` (not needed with `claude_code_oauth_token`) from both Claude workflows.

## 6. Hardening
`timeout-minutes: 15` and a concurrency group on the network-bound sync, plus a comment on its `name:` warning that `publish.yml` chains off that exact string via `workflow_run`. Added `dependabot.yml` for monthly action bumps (npm deliberately excluded, Astro upgrades stay manual).

## Verification
- All 5 workflows + `dependabot.yml` parse as valid YAML; triggers, paths, permissions, and concurrency asserted programmatically
- Commit gate tested across the 3 scenarios above in a scratch repo
- Path filters dry-run against the last 6 real commits: 4 of 6 would fire at least one audit
- `bun run build` passes, 28 pages, clean tree

## Known caveats
- `ci.yml` will not run on this PR itself; the trigger only exists once merged. The first PR after merge exercises it.
- The publication sync pushes with `GITHUB_TOKEN`, which by GitHub's anti-recursion rule does not fire `push` workflows. Synced publication `.mdx` files therefore skip the WCAG audit. Harmless in practice (generated frontmatter, no markup), and the same rule is why `publish.yml` needs its `workflow_run` chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)