### PR TITLE
ci: fix agent workflows failing on push, drop WCAG turn cap

### DIFF
--- a/.github/workflows/doc-cleaner-claude.yml
+++ b/.github/workflows/doc-cleaner-claude.yml
@@ -23,20 +23,42 @@ on:
       - '.github/workflows/**'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
-  group: "doc-cleaner"
+  # Scoped by event so the short dispatch job below never cancels the long
+  # audit run it just started (they are separate runs of this same workflow).
+  group: "doc-cleaner-${{ github.event_name }}"
   # Only the latest state of main is worth auditing; superseded runs would
   # otherwise queue for a full 20 minutes each.
   cancel-in-progress: true
 
 jobs:
+  # claude-code-action rejects the push event outright ("Unsupported event type:
+  # push"), so the trigger above cannot drive the agent directly. This job
+  # re-enters the workflow via workflow_dispatch, which is a supported event and
+  # which GITHUB_TOKEN is explicitly permitted to trigger -- the documented
+  # exception to GitHub's anti-recursion rule that otherwise ignores
+  # token-driven events. Path filtering thus stays declarative in `on:` above.
+  dispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Re-trigger this workflow as workflow_dispatch
+        run: gh workflow run doc-cleaner-claude.yml --ref "$GITHUB_REF_NAME"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
   clean:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/wcag-audit-claude.yml
+++ b/.github/workflows/wcag-audit-claude.yml
@@ -19,27 +19,53 @@ on:
       - 'src/styles/**'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 concurrency:
-  group: "wcag-audit"
+  # Scoped by event so the short dispatch job below never cancels the long
+  # audit run it just started (they are separate runs of this same workflow).
+  group: "wcag-audit-${{ github.event_name }}"
   # Only the latest state of main is worth auditing; superseded runs would
   # otherwise queue for a full 30 minutes each.
   cancel-in-progress: true
 
 jobs:
+  # claude-code-action rejects the push event outright ("Unsupported event type:
+  # push"), so the trigger above cannot drive the agent directly. This job
+  # re-enters the workflow via workflow_dispatch, which is a supported event and
+  # which GITHUB_TOKEN is explicitly permitted to trigger -- the documented
+  # exception to GitHub's anti-recursion rule that otherwise ignores
+  # token-driven events. Path filtering thus stays declarative in `on:` above.
+  dispatch:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Re-trigger this workflow as workflow_dispatch
+        run: gh workflow run wcag-audit-claude.yml --ref "$GITHUB_REF_NAME"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+
   audit:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v7
 
+      # No --max-turns: the 2026-07-05 run died on "Reached maximum number of
+      # turns (30)" before it could report or open a PR. This audit reads every
+      # .astro/.css/.mdx file, so 30 turns is not a realistic budget. Cost stays
+      # bounded by timeout-minutes above -- the same call made for the doc
+      # cleaner in 055c900.
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 30"
           prompt: |
             # WCAG Compliance Auditor
 


### PR DESCRIPTION
## Problem

`8b2354a` switched the Documentation Cleaner and WCAG Auditor from crons to `push` triggers. `claude-code-action@v1` rejects that event outright:

```
##[error]Action failed with error: Unsupported event type: push
```

Its context parser accepts only `issues`, `issue_comment`, `pull_request`, `pull_request_target`, `pull_request_review`, `pull_request_review_comment`, `workflow_dispatch`, `repository_dispatch`, `schedule`, `workflow_run`. So every qualifying push to main failed within ~2 seconds. The doc cleaner failed twice ([30131534309](../../actions/runs/30131534309), [30131461240](../../actions/runs/30131461240)); WCAG carried the identical bug and had simply not yet seen a push touching `src/**/*.astro|css|mdx`.

## Fix

Keep the `push` trigger and its path filters, but re-enter via `workflow_dispatch` — an event the action supports and one `GITHUB_TOKEN` is permitted to fire. Per GitHub's docs, *"workflow_dispatch and repository_dispatch events always create workflow runs"*, the documented exception to the anti-recursion rule that ignores token-driven pushes.

| Job | Runs on | Does |
| --- | --- | --- |
| `dispatch` | `push` | `gh workflow run <file> --ref main` |
| `clean` / `audit` | `workflow_dispatch` | the agent |

Alternatives rejected: reinstating the crons undoes `9781816`'s deliberate retirement; chaining `workflow_run` off the publish job has no path filters, so the doc cleaner would rerun on every content edit — the exact noise its path list exists to prevent.

Also removes `--max-turns 30` from the WCAG audit, which killed the [2026-07-05 run](../../actions/runs/28754149366) (`Reached maximum number of turns (30)`) before it could report or open a PR. That audit reads every `.astro`/`.css`/`.mdx` file, so 30 turns is not a realistic budget; `timeout-minutes: 30` still bounds cost — the same call `055c900` made for the doc cleaner.

Secondary changes: concurrency groups scoped by event, so the seconds-long `dispatch` job cannot `cancel-in-progress` the long audit run it just queued; permissions narrowed per-job (`actions: write` to dispatch, `contents`/`pull-requests: write` to the agent) instead of workflow-wide.

## Verification

- `actionlint` 1.7.12 clean across all five workflows (includes shellcheck of `run:` steps).
- The `GITHUB_TOKEN` → `workflow_dispatch` exception confirmed against GitHub's docs, not assumed.
- The agent step is already proven on this event: the doc cleaner has 1 successful `workflow_dispatch` run and 19 successful `schedule` runs; only the `push` path was ever broken.
- Not yet exercised end-to-end: `workflow_dispatch` requires the file on the default branch, so the push → dispatch → agent chain first runs for real on the next qualifying push after merge. Watch that the dispatcher run is followed by a second, agent-driven run.

## Not in scope

The 4th historical doc-cleaner failure ([22832508320](../../actions/runs/22832508320), 2026-03-08) predates the `id-token: write` fix in `f3f27fc`; its logs have expired and later runs on the same event succeeded. The June failure was already fixed by `055c900`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)